### PR TITLE
fix readme.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ antonyms = ["insane", "indirect", "formally", "popular", "additive", "residentia
 
 result, demo_fn = ape.simple_ape(
     dataset=(words, antonyms),
-    eval_template=eval_template,
 )
 ```
 


### PR DESCRIPTION
This removes the `eval_template=eval_template,` in the example which errors out because no eval_template is provided